### PR TITLE
Another syntax error in js tests

### DIFF
--- a/code/tests.js
+++ b/code/tests.js
@@ -31,7 +31,7 @@ var tests = {
     },
     squareRootTest: function() {
         assert.areEqual(5.0, code.squareRoot(25.0));
-        assert.IsInRange(1.414, 1.4144, code.squareRoot(2.0));
+        assert.isInRange(1.414, 1.4144, code.squareRoot(2.0));
     }
 
 };

--- a/code/tests.js
+++ b/code/tests.js
@@ -30,7 +30,7 @@ var tests = {
         assert.areEqual(6765, code.fibonacci(20));
     },
     squareRootTest: function() {
-        assert.AreEqual(5.0, code.squareRoot(25.0));
+        assert.areEqual(5.0, code.squareRoot(25.0));
         assert.IsInRange(1.414, 1.4144, code.squareRoot(2.0));
     }
 


### PR DESCRIPTION
Capitalized `AreEqual` instead of `areEqual` on `assert`
